### PR TITLE
Fix Multiverse/Multiverse-NetherPortals#68

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
@@ -49,6 +49,7 @@ public class MVNPPlayerListener implements Listener {
         PortalType type = PortalType.END;
         if (event.getFrom().getBlock().getType() == Material.PORTAL) {
             type = PortalType.NETHER;
+            event.useTravelAgent(true);
         }
 
         String linkedWorld = this.plugin.getWorldLink(currentWorld, type);


### PR DESCRIPTION
This was caused by Bukkit/CraftBukkit@de86f8c

When the portal in question is a Nether portal, re-enable useTravelAgent().

A build with this fix for testing can be found here:
http://dl.dropbox.com/u/71355/Multiverse-NetherPortals-2.5_issue68.jar
