### PR TITLE
Don't handle portals which are handled by Multiverse-Portals.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,15 @@
             <scope>compile</scope>
         </dependency>
         <!-- End of Multiverse Core Dependency -->
+        <!-- Start of Multiverse Portals Dependency -->
+        <dependency>
+            <groupId>com.onarandombox.multiverseportals</groupId>
+            <artifactId>Multiverse-Portals</artifactId>
+            <version>2.5</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+        <!-- End of Multiverse Portals Dependency -->
         <!-- Start of Logging Dependency -->
         <dependency>
             <groupId>com.dumptruckman.minecraft</groupId>

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/MultiverseNetherPortals.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/MultiverseNetherPortals.java
@@ -12,6 +12,7 @@ import com.onarandombox.MultiverseNetherPortals.listeners.MVNPCoreListener;
 import com.onarandombox.MultiverseNetherPortals.listeners.MVNPEntityListener;
 import com.onarandombox.MultiverseNetherPortals.listeners.MVNPPlayerListener;
 import com.onarandombox.MultiverseNetherPortals.listeners.MVNPPluginListener;
+import com.onarandombox.MultiversePortals.MultiversePortals;
 import com.pneumaticraft.commandhandler.multiverse.CommandHandler;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -29,11 +30,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
+import org.bukkit.Location;
+import org.bukkit.plugin.Plugin;
 
 public class MultiverseNetherPortals extends JavaPlugin implements MVPlugin {
 
     private static final String NETEHR_PORTALS_CONFIG = "config.yml";
     protected MultiverseCore core;
+    protected Plugin multiversePortals;
     protected MVNPPluginListener pluginListener;
     protected MVNPPlayerListener playerListener;
     protected MVNPCoreListener customListener;
@@ -54,6 +58,7 @@ public class MultiverseNetherPortals extends JavaPlugin implements MVPlugin {
     public void onEnable() {
         Logging.init(this);
         this.core = (MultiverseCore) getServer().getPluginManager().getPlugin("Multiverse-Core");
+        this.multiversePortals = getServer().getPluginManager().getPlugin("Multiverse-Portals");
 
         // Test if the Core was found, if not we'll disable this plugin.
         if (this.core == null) {
@@ -263,6 +268,29 @@ public class MultiverseNetherPortals extends JavaPlugin implements MVPlugin {
 
     public void setUsingBounceBack(boolean useBounceBack) {
         this.MVNPconfiguration.set("bounceback", useBounceBack);
+    }
+
+    public boolean isHandledByNetherPortals(Location l) {
+        if (multiversePortals != null) {
+            // Catch errors which could occur if classes aren't present or are missing methods.
+            try {
+                MultiversePortals portals = (MultiversePortals) multiversePortals;
+                if (portals.getPortalManager().isPortal(l)) {
+                    return false;
+                }
+            } catch (Throwable t) {
+                getLogger().log(Level.WARNING, "Error checking if portal is handled by Multiverse-Portals", t);
+            }
+        }
+        return true;
+    }
+
+    public void setPortals(Plugin multiversePortals) {
+        this.multiversePortals = multiversePortals;
+    }
+
+    public Plugin getPortals() {
+        return multiversePortals;
     }
 
     @Override

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
@@ -94,6 +94,11 @@ public class MVNPEntityListener implements Listener {
 
         Player p = (Player) event.getEntity();
         Location block = this.locationManipulation.getBlockLocation(p.getLocation());
+
+        if (!plugin.isHandledByNetherPortals(block)) {
+            return;
+        }
+
         if(this.eventRecord.containsKey(p.getName())) {
             // The the eventRecord shows this player was already trying to go somewhere.
             if (this.locationManipulation.getBlockLocation(p.getLocation()).equals(this.eventRecord.get(p.getName()))) {

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
@@ -44,6 +44,9 @@ public class MVNPPlayerListener implements Listener {
             originalTo = originalTo.clone();
         }
         Location currentLocation = event.getFrom().clone();
+        if (!plugin.isHandledByNetherPortals(currentLocation)) {
+            return;
+        }
         String currentWorld = currentLocation.getWorld().getName();
 
         PortalType type = PortalType.END;

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPluginListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPluginListener.java
@@ -22,6 +22,9 @@ public class MVNPPluginListener implements Listener {
             this.plugin.setCore(((MultiverseCore) this.plugin.getServer().getPluginManager().getPlugin("Multiverse-Core")));
             this.plugin.getServer().getPluginManager().enablePlugin(this.plugin);
         }
+        if (event.getPlugin().getDescription().getName().equals("Multiverse-Portals")) {
+            this.plugin.setPortals(event.getPlugin());
+        }
     }
 
     @EventHandler
@@ -29,6 +32,9 @@ public class MVNPPluginListener implements Listener {
         if (event.getPlugin().getDescription().getName().equals("Multiverse-Core")) {
             this.plugin.setCore(null);
             this.plugin.getServer().getPluginManager().disablePlugin(this.plugin);
+        }
+        if (event.getPlugin().getDescription().getName().equals("Multiverse-Portals")) {
+            this.plugin.setPortals(null);
         }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ main: com.onarandombox.MultiverseNetherPortals.MultiverseNetherPortals
 authors: ['Rigby', 'fernferret']
 version: maven-version-number
 depend: ['Multiverse-Core']
+softdepend: ['Multiverse-Portals']
 commands:
   mvnp:
     description: Generic Multiverse-NetherPortals Command


### PR DESCRIPTION
Adds a soft dependency on Multiverse-Portals.

Before handling events, call into Multiverse-Portals (if present) and check if the portal block is part of a portal belonging to Multiverse-Portals. If it is, ignore the event.
