### PR TITLE
Fix infinite end portal loop

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
@@ -87,7 +87,7 @@ public class MVNPPlayerListener implements Listener {
         if (event.getFrom().getWorld().equals(event.getTo().getWorld())) {
             // The player is Portaling to the same world.
             this.plugin.log(Level.FINER, "Player '" + event.getPlayer().getName() + "' is portaling to the same world.  Ignoring.");
-            event.setTo(originalTo);
+            event.setCancelled(true);
             return;
         }
         MultiverseWorld fromWorld = this.worldManager.getMVWorld(event.getFrom().getWorld().getName());


### PR DESCRIPTION
I don't know if this has any side effects, but it removed the "Cannot use null location!" exception and our server doesn't crash anymore.

Should resolve #113, #108, #105 and #104.
