### PR TITLE
1.14 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <version>1.14.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
@@ -54,7 +54,6 @@ public class MVNPPlayerListener implements Listener {
         PortalType type = PortalType.END;
         if (event.getFrom().getBlock().getType() == Material.NETHER_PORTAL) {
             type = PortalType.NETHER;
-            event.useTravelAgent(true);
         }
 
         String linkedWorld = this.plugin.getWorldLink(currentWorld, type);
@@ -96,7 +95,6 @@ public class MVNPPlayerListener implements Listener {
         if (!event.isCancelled()) {
             if (fromWorld.getEnvironment() == World.Environment.THE_END && type == PortalType.END) {
                 this.plugin.log(Level.FINE, "Player '" + event.getPlayer().getName() + "' will be teleported to the spawn of '" + toWorld.getName() + "' since they used an end exit portal.");
-                event.getPortalTravelAgent().setCanCreatePortal(false);
                 if (toWorld.getBedRespawn()
                         && event.getPlayer().getBedSpawnLocation() != null
                         && event.getPlayer().getBedSpawnLocation().getWorld().getUID() == toWorld.getCBWorld().getUID()) {
@@ -105,8 +103,7 @@ public class MVNPPlayerListener implements Listener {
                     event.setTo(toWorld.getSpawnLocation());
                 }
             } else if (fromWorld.getEnvironment() == World.Environment.NETHER && type == PortalType.NETHER) {
-                event.getPortalTravelAgent().setCanCreatePortal(true);
-                event.setTo(event.getPortalTravelAgent().findOrCreate(event.getTo()));
+                event.setTo(event.getTo());
             } else if (toWorld.getEnvironment() == World.Environment.THE_END && type == PortalType.END) {
                 Location loc = new Location(event.getTo().getWorld(), 100, 50, 0); // This is the vanilla location for obsidian platform.
                 event.setTo(loc);


### PR DESCRIPTION
Naive fix for 1.14.

Nether portal detection seems to work, even though we no longer use TravelAgent (removed in 1.14 Bukkit by Spigot).

Returning from the End seems to throw you out of a nether portal.