### PR TITLE
Teleport Entities to Correct World

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/MultiverseNetherPortals.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/MultiverseNetherPortals.java
@@ -276,16 +276,16 @@ public class MultiverseNetherPortals extends JavaPlugin implements MVPlugin {
         return this.MVNPconfiguration.getBoolean("send_no_destination_message", true);
     }
 
-    public void setSendingNoDestinationMessage(boolean useBounceBack) {
-        this.MVNPconfiguration.set("send_no_destination_message", useBounceBack);
+    public void setSendingNoDestinationMessage(boolean sendNoDestinationMessage) {
+        this.MVNPconfiguration.set("send_no_destination_message", sendNoDestinationMessage);
     }
 
     public boolean isSendingDisabledPortalMessage() {
         return this.MVNPconfiguration.getBoolean("send_portal_disabled_message", true);
     }
 
-    public void setSendingDisabledPortalMessage(boolean useBounceBack) {
-        this.MVNPconfiguration.set("send_portal_disabled_message", useBounceBack);
+    public void setSendingDisabledPortalMessage(boolean sendDisabledPortalMessage) {
+        this.MVNPconfiguration.set("send_portal_disabled_message", sendDisabledPortalMessage);
     }
 
     public boolean isHandledByNetherPortals(Location l) {

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/MultiverseNetherPortals.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/MultiverseNetherPortals.java
@@ -110,6 +110,7 @@ public class MultiverseNetherPortals extends JavaPlugin implements MVPlugin {
         this.endLinkMap = new HashMap<String, String>();
 
         this.setUsingBounceBack(this.isUsingBounceBack());
+        this.setTeleportingEntities(this.isTeleportingEntities());
         this.setSendingNoDestinationMessage(this.isSendingNoDestinationMessage());
         this.setSendingDisabledPortalMessage(this.isSendingDisabledPortalMessage());
         this.setNetherPrefix(this.MVNPconfiguration.getString("netherportals.name.prefix", this.getNetherPrefix()));
@@ -270,6 +271,14 @@ public class MultiverseNetherPortals extends JavaPlugin implements MVPlugin {
 
     public void setUsingBounceBack(boolean useBounceBack) {
         this.MVNPconfiguration.set("bounceback", useBounceBack);
+    }
+
+    public boolean isTeleportingEntities() {
+        return this.MVNPconfiguration.getBoolean("send_no_destination_message", true);
+    }
+
+    public void setTeleportingEntities(boolean teleportingEntities) {
+        this.MVNPconfiguration.set("send_no_destination_message", teleportingEntities);
     }
 
     public boolean isSendingNoDestinationMessage() {

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
@@ -41,9 +41,10 @@ public class MVNPEntityListener implements Listener {
     private final Map<String, Date> playerErrors;
     private final LocationManipulation locationManipulation;
     private final MVEventRecord eventRecord;
-    // This map will track whether each player is touching a portal.
-    // We can use this to avoid lots of unnecessary calls to the
-    // on entity portal touch calculations.
+    // the event record is used to track players that are currently standing
+    // inside portals. it's used so that we don't need to run the the onEntityPortalEnter
+    // listener more than once for a given player. that also means players are
+    // only messaged once about why they can't go through a given portal.
 
     public MVNPEntityListener(MultiverseNetherPortals plugin) {
         this.plugin = plugin;
@@ -144,13 +145,12 @@ public class MVNPEntityListener implements Listener {
             return;
         }
 
-        BukkitTask isTouching;
         if (eventRecord.isInRecord(type, p.getUniqueId())) {
             // no need to carry on, the player is already in the event record
             return;
         } else {
-            // this runnable will check if the player is still standing in the portal
-            // if they aren't, it will remove them from the event record
+            // we'll add the player to the event record since they're standing
+            // in a portal. they'll automatically be removed when they leave
             eventRecord.addToRecord(type, p.getUniqueId());
         }
 

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/utils/MVLinkChecker.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/utils/MVLinkChecker.java
@@ -4,6 +4,7 @@ import com.onarandombox.MultiverseCore.api.MVWorldManager;
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseNetherPortals.MultiverseNetherPortals;
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 import java.util.logging.Level;
@@ -17,17 +18,17 @@ public class MVLinkChecker {
         this.worldManager = this.plugin.getCore().getMVWorldManager();
     }
 
-    public Location findNewTeleportLocation(Location fromLocation, String worldstring, Player p) {
+    public Location findNewTeleportLocation(Location fromLocation, String worldstring, Entity e) {
         MultiverseWorld tpto = this.worldManager.getMVWorld(worldstring);
 
         if (tpto == null) {
             this.plugin.log(Level.FINE, "Can't find world " + worldstring);
-        } else if (!this.plugin.getCore().getMVPerms().canEnterWorld(p, tpto)) {
-            this.plugin.log(Level.WARNING, "Player " + p.getName() + " can't enter world " + worldstring);
+        } else if (e instanceof Player && !this.plugin.getCore().getMVPerms().canEnterWorld((Player) e, tpto)) {
+            this.plugin.log(Level.WARNING, "Player " + e.getName() + " can't enter world " + worldstring);
         } else if (!this.worldManager.isMVWorld(fromLocation.getWorld().getName())) {
             this.plugin.log(Level.WARNING, "World " + fromLocation.getWorld().getName() + " is not a Multiverse world");
         } else {
-            this.plugin.log(Level.FINE, "Finding new teleport location for player " + p.getName() + " to world " + worldstring);
+            this.plugin.log(Level.FINE, "Finding new teleport location for entity " + e.getName() + " to world " + worldstring);
 
             // Set the output location to the same XYZ coords but different world
             double toScaling = this.worldManager.getMVWorld(tpto.getName()).getScaling();


### PR DESCRIPTION
This PR fixes #72. It also adds a config option to disallow entities from being teleported through portals.

The issue was that there was no EntityPortalEvent handler to change which world the entity is being sent to. However, it would seem there is a bug in the Event, as using the getFrom() method results in the block next to the portal, rather than in the portal. I've worked around this by making a new Location with rounded values, but this seems to only work sometimes. Please see Line 227 of the MVNPEntityListener class to see the workaround.