### PR TITLE
Update MV Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.onarandombox.multiversenetherportals</groupId>
     <artifactId>Multiverse-NetherPortals</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
     <name>Multiverse-NetherPortals</name>
     <description>Multiverse Nether Portals module</description>
     <properties>
@@ -155,14 +155,14 @@
         <dependency>
             <groupId>com.onarandombox.multiversecore</groupId>
             <artifactId>Multiverse-Core</artifactId>
-            <version>4.1.0</version>
+            <version>4.2.0-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.onarandombox.multiverseportals</groupId>
             <artifactId>Multiverse-Portals</artifactId>
-            <version>4.1.0</version>
+            <version>4.2.0-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
MV NetherPortals doesn't actually use TravelAgent, which is funny because the Javadoc for TravelAgent says it's meant to help developers mimic Vanilla behaviour, and I'd argue that MV NetherPortals is the most Vanilla behaving sub-plugin. Anyways, this PR just bumps the version numbers to match the rest of MV.