### PR TITLE
Fix MV Portals Support

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
@@ -93,7 +93,7 @@ public class MVNPEntityListener implements Listener {
         }
 
         Player p = (Player) event.getEntity();
-        Location block = this.locationManipulation.getBlockLocation(p.getLocation());
+        Location block = this.locationManipulation.getBlockLocation(event.getLocation());
 
         if (!plugin.isHandledByNetherPortals(block)) {
             return;


### PR DESCRIPTION
This PR fixes Multiverse/Multiverse-Portals#300. I believe the issue was already fixed, however, the issue where MV Portals were seen as Nether Portals by MV NetherPortals remained (meaning a message is sent to the player and they're bounced back if the world they're on doesn't have a nether world). This PR corrects that. 