### PR TITLE
Teleport Entities to Correct World

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/MultiverseNetherPortals.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/MultiverseNetherPortals.java
@@ -110,6 +110,7 @@ public class MultiverseNetherPortals extends JavaPlugin implements MVPlugin {
         this.endLinkMap = new HashMap<String, String>();
 
         this.setUsingBounceBack(this.isUsingBounceBack());
+        this.setTeleportingEntities(this.isTeleportingEntities());
         this.setSendingNoDestinationMessage(this.isSendingNoDestinationMessage());
         this.setSendingDisabledPortalMessage(this.isSendingDisabledPortalMessage());
         this.setNetherPrefix(this.MVNPconfiguration.getString("netherportals.name.prefix", this.getNetherPrefix()));
@@ -270,6 +271,14 @@ public class MultiverseNetherPortals extends JavaPlugin implements MVPlugin {
 
     public void setUsingBounceBack(boolean useBounceBack) {
         this.MVNPconfiguration.set("bounceback", useBounceBack);
+    }
+
+    public boolean isTeleportingEntities() {
+        return this.MVNPconfiguration.getBoolean("send_no_destination_message", true);
+    }
+
+    public void setTeleportingEntities(boolean teleportingEntities) {
+        this.MVNPconfiguration.set("send_no_destination_message", teleportingEntities);
     }
 
     public boolean isSendingNoDestinationMessage() {

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
@@ -13,15 +13,19 @@ import com.onarandombox.MultiverseNetherPortals.utils.MVNameChecker;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.PortalType;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityPortalEnterEvent;
+import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.entity.EntityPortalExitEvent;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -121,6 +125,49 @@ public class MVNPEntityListener implements Listener {
         return playerBounced;
     }
 
+    /**
+     * Figures out the destination of a portal, given its type, and the world it resides on.
+     *
+     * @param e               The entity in the portal.
+     * @param currentLocation The location of the portal.
+     * @param type            The type of the portal. Must be a value from the PortalType enum.
+     * @param currentWorld    The name of the world the portal resides on.
+     * @param linkedWorld     The name of the world linked to {@code currentWorld}, if any.
+     * @return
+     */
+    @Nullable
+    private Location getLocation(Entity e, Location currentLocation, PortalType type, String currentWorld, String linkedWorld) {
+        Location newTo = null;
+
+        if (!currentWorld.equalsIgnoreCase(linkedWorld)) {
+            String destinationWorld = "";
+
+            if (this.nameChecker.isValidEndName(currentWorld)) {
+                if (type == PortalType.ENDER) {
+                    destinationWorld = this.nameChecker.getNormalName(currentWorld, type);
+                } else if (type == PortalType.NETHER) {
+                    destinationWorld = this.nameChecker.getNetherName(this.nameChecker.getNormalName(currentWorld, type));
+                }
+            } else if (this.nameChecker.isValidNetherName(currentWorld)) {
+                if (type == PortalType.ENDER) {
+                    destinationWorld = this.nameChecker.getEndName(this.nameChecker.getNormalName(currentWorld, type));
+                } else if (type == PortalType.NETHER) {
+                    destinationWorld = this.nameChecker.getNormalName(currentWorld, type);
+                }
+            } else {
+                if (type == PortalType.ENDER) {
+                    destinationWorld = this.nameChecker.getEndName(currentWorld);
+                } else if (type == PortalType.NETHER) {
+                    destinationWorld = this.nameChecker.getNetherName(currentWorld);
+                }
+            }
+
+            newTo = this.linkChecker.findNewTeleportLocation(currentLocation, destinationWorld, e);
+        }
+
+        return newTo;
+    }
+
     @EventHandler(priority = EventPriority.MONITOR)
     public void onEntityPortalEnter(EntityPortalEnterEvent event) {
         if (!(event.getEntity() instanceof Player)) {
@@ -128,17 +175,17 @@ public class MVNPEntityListener implements Listener {
         }
 
         Player p = (Player) event.getEntity();
-        Location block = this.locationManipulation.getBlockLocation(event.getLocation());
+        Location currentLocation = this.locationManipulation.getBlockLocation(event.getLocation());
 
-        if (!plugin.isHandledByNetherPortals(block)) {
+        if (!plugin.isHandledByNetherPortals(currentLocation)) {
             return;
         }
 
         PortalType type;
         // determine what kind of portal the player is using
-        if (block.getBlock().getType() == Material.END_PORTAL) {
+        if (currentLocation.getBlock().getType() == Material.END_PORTAL) {
             type = PortalType.ENDER;
-        } else if (block.getBlock().getType() == Material.NETHER_PORTAL) {
+        } else if (currentLocation.getBlock().getType() == Material.NETHER_PORTAL) {
             type = PortalType.NETHER;
         } else {
             return;
@@ -177,35 +224,9 @@ public class MVNPEntityListener implements Listener {
             this.playerErrors.remove(p.getName());
         }
 
-        String currentWorld = event.getLocation().getWorld().getName();
-        String linkedWorld = this.plugin.getWorldLink(event.getLocation().getWorld().getName(), type);
-        Location currentLocation = event.getLocation();
-
-        Location toLocation;
-
-        if (currentWorld.equalsIgnoreCase(linkedWorld)) {
-            toLocation = null;
-        } else if (linkedWorld != null) {
-            toLocation = this.linkChecker.findNewTeleportLocation(currentLocation, linkedWorld, p);
-        } else if (this.nameChecker.isValidNetherName(currentWorld)) {
-            if (type == PortalType.NETHER) {
-                toLocation = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getNormalName(currentWorld, PortalType.NETHER), p);
-            } else {
-                toLocation = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getEndName(this.nameChecker.getNormalName(currentWorld, PortalType.NETHER)), p);
-            }
-        } else if (this.nameChecker.isValidEndName(currentWorld)) {
-            if (type == PortalType.NETHER) {
-                toLocation = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getNetherName(this.nameChecker.getNormalName(currentWorld, PortalType.ENDER)), p);
-            } else {
-                toLocation = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getNormalName(currentWorld, PortalType.ENDER), p);
-            }
-        } else {
-            if (type == PortalType.ENDER) {
-                toLocation = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getEndName(currentWorld), p);
-            } else {
-                toLocation = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getNetherName(currentWorld), p);
-            }
-        }
+        String currentWorld = currentLocation.getWorld().getName();
+        String linkedWorld = this.plugin.getWorldLink(currentWorld, type);
+        Location toLocation = getLocation(p, currentLocation, type, currentWorld, linkedWorld);
 
         if (toLocation == null) {
             if (this.shootPlayer(p, eventLocation.getBlock(), type)) {
@@ -263,6 +284,102 @@ public class MVNPEntityListener implements Listener {
             }
         } else {
             this.plugin.log(Level.FINE, "Player '" + p.getName() + "' was allowed to go to '" + toWorld.getCBWorld().getName() + "' because enforceaccess is off.");
+        }
+    }
+
+    @EventHandler
+    public void onEntityPortal(EntityPortalEvent event) {
+        if (event.isCancelled()) {
+            this.plugin.log(Level.FINEST, "EntityPortalEvent was cancelled! NOT teleporting!");
+            return;
+        }
+
+        Entity e = event.getEntity();
+        Location originalTo = this.locationManipulation.getBlockLocation(event.getTo());
+        Location currentLocation = this.locationManipulation.getBlockLocation(event.getFrom());
+
+        if (!plugin.isHandledByNetherPortals(currentLocation)) {
+            return;
+        }
+
+        if (!this.plugin.isTeleportingEntities()) {
+            event.setCancelled(true);
+            return;
+        }
+
+        PortalType type;
+        if (this.nameChecker.isValidNetherName(originalTo.getWorld().getName())
+                || (currentLocation.getWorld().getEnvironment() == World.Environment.NETHER && originalTo.getWorld().getEnvironment() == World.Environment.NORMAL)) {
+            type = PortalType.NETHER;
+        } else if (this.nameChecker.isValidEndName(originalTo.getWorld().getName())
+                || (currentLocation.getWorld().getEnvironment() == World.Environment.THE_END && originalTo.getWorld().getEnvironment() == World.Environment.NORMAL)) {
+            type = PortalType.ENDER;
+        } else {
+            return;
+        }
+
+        if (type == PortalType.NETHER) {
+            try {
+                Class.forName("org.bukkit.TravelAgent");
+                event.useTravelAgent(true);
+            } catch (ClassNotFoundException ignore) {
+                plugin.log(Level.FINE, "TravelAgent not available for EntityPortalEvent for " + e.getName());
+            }
+        }
+
+        String currentWorld = currentLocation.getWorld().getName();
+        String linkedWorld = this.plugin.getWorldLink(currentWorld, type);
+        Location newTo = getLocation(e, currentLocation, type, currentWorld, linkedWorld);
+
+        if (newTo != null) {
+            event.setTo(newTo);
+        } else {
+            event.setCancelled(true);
+            return;
+        }
+
+        MultiverseWorld fromWorld = this.worldManager.getMVWorld(event.getFrom().getWorld().getName());
+        MultiverseWorld toWorld = this.worldManager.getMVWorld(event.getTo().getWorld().getName());
+
+        if (!event.isCancelled()) {
+            if (fromWorld.getEnvironment() == World.Environment.THE_END && type == PortalType.ENDER) {
+                this.plugin.log(Level.FINE, "Entity '" + e.getName() + "' will be teleported to the spawn of '" + toWorld.getName() + "' since they used an end exit portal.");
+                try {
+                    Class.forName("org.bukkit.TravelAgent");
+                    event.getPortalTravelAgent().setCanCreatePortal(false);
+                } catch (ClassNotFoundException ignore) {
+                    plugin.log(Level.FINE, "TravelAgent not available for EntityPortalEvent for " + e.getName() + ". There may be a portal created at spawn.");
+                }
+
+                event.setTo(toWorld.getSpawnLocation());
+            } else if (fromWorld.getEnvironment() == World.Environment.NETHER && type == PortalType.NETHER) {
+                try {
+                    Class.forName("org.bukkit.TravelAgent");
+                    event.getPortalTravelAgent().setCanCreatePortal(true);
+                    event.setTo(event.getPortalTravelAgent().findOrCreate(event.getTo()));
+                } catch (ClassNotFoundException ignore) {
+                    plugin.log(Level.FINE, "TravelAgent not available for EntityPortalEvent for " + e.getName() + ". Their destination may not be correct.");
+                    event.setTo(event.getTo());
+                }
+            } else if (toWorld.getEnvironment() == World.Environment.THE_END && type == PortalType.ENDER) {
+                Location loc = new Location(event.getTo().getWorld(), 100, 50, 0); // This is the vanilla location for obsidian platform.
+                event.setTo(loc);
+                Block block = loc.getBlock();
+                for (int x = block.getX() - 2; x <= block.getX() + 2; x++) {
+                    for (int z = block.getZ() - 2; z <= block.getZ() + 2; z++) {
+                        Block platformBlock = loc.getWorld().getBlockAt(x, block.getY() - 1, z);
+                        if (platformBlock.getType() != Material.OBSIDIAN) {
+                            platformBlock.setType(Material.OBSIDIAN);
+                        }
+                        for (int yMod = 1; yMod <= 3; yMod++) {
+                            Block b = platformBlock.getRelative(BlockFace.UP, yMod);
+                            if (b.getType() != Material.AIR) {
+                                b.setType(Material.AIR);
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/utils/MVLinkChecker.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/utils/MVLinkChecker.java
@@ -4,6 +4,7 @@ import com.onarandombox.MultiverseCore.api.MVWorldManager;
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseNetherPortals.MultiverseNetherPortals;
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 import java.util.logging.Level;
@@ -17,35 +18,37 @@ public class MVLinkChecker {
         this.worldManager = this.plugin.getCore().getMVWorldManager();
     }
 
-    public Location findNewTeleportLocation(Location fromLocation, String worldstring, Player p) {
-        MultiverseWorld tpto = this.worldManager.getMVWorld(worldstring);
+    public Location findNewTeleportLocation(Location fromLocation, String worldString, Entity e) {
+        MultiverseWorld tpTo = this.worldManager.getMVWorld(worldString);
 
-        if (tpto == null) {
-            this.plugin.log(Level.FINE, "Can't find world " + worldstring);
-        } else if (!this.plugin.getCore().getMVPerms().canEnterWorld(p, tpto)) {
-            this.plugin.log(Level.WARNING, "Player " + p.getName() + " can't enter world " + worldstring);
+        if (tpTo == null) {
+            this.plugin.log(Level.FINE, "Can't find world " + worldString);
+        } else if (e instanceof Player && !this.plugin.getCore().getMVPerms().canEnterWorld((Player) e, tpTo)) {
+            this.plugin.log(Level.WARNING, "Player " + e.getName() + " can't enter world " + worldString);
         } else if (!this.worldManager.isMVWorld(fromLocation.getWorld().getName())) {
             this.plugin.log(Level.WARNING, "World " + fromLocation.getWorld().getName() + " is not a Multiverse world");
         } else {
-            this.plugin.log(Level.FINE, "Finding new teleport location for player " + p.getName() + " to world " + worldstring);
+            String entityType = (e instanceof Player) ? " player " : " entity ";
+            this.plugin.log(Level.FINE, "Finding new teleport location for" + entityType + e.getName() + " to world " + worldString);
 
             // Set the output location to the same XYZ coords but different world
-            double toScaling = this.worldManager.getMVWorld(tpto.getName()).getScaling();
-            MultiverseWorld tpfrom = this.worldManager.getMVWorld(fromLocation.getWorld().getName());
-            double fromScaling = tpfrom.getScaling();
-            double yScaling = 1d * tpfrom.getCBWorld().getMaxHeight() / tpto.getCBWorld().getMaxHeight();
-            fromLocation = this.getScaledLocation(fromLocation, fromScaling, toScaling, yScaling);
-            fromLocation.setWorld(tpto.getCBWorld());
+            MultiverseWorld tpFrom = this.worldManager.getMVWorld(fromLocation.getWorld().getName());
+
+            double fromScaling = tpFrom.getScaling();
+            double toScaling = this.worldManager.getMVWorld(tpTo.getName()).getScaling();
+            double yScaling = 1d * tpFrom.getCBWorld().getMaxHeight() / tpTo.getCBWorld().getMaxHeight();
+
+            this.scaleLocation(fromLocation, fromScaling / toScaling, yScaling);
+            fromLocation.setWorld(tpTo.getCBWorld());
             return fromLocation;
         }
+
         return null;
     }
 
-    private Location getScaledLocation(Location fromLocation, double fromScaling, double toScaling, double yScaling) {
-        double scaling = fromScaling / toScaling;
+    private void scaleLocation(Location fromLocation, double scaling, double yScaling) {
         fromLocation.setX(fromLocation.getX() * scaling);
         fromLocation.setZ(fromLocation.getZ() * scaling);
         fromLocation.setY(fromLocation.getY() * yScaling);
-        return fromLocation;
     }
 }


### PR DESCRIPTION
This PR makes it so that when an entity enters a portal, they are teleported to the correct world. This fixes #72.

Note, this PR is equivalent to #156, but is rebased on the `event_tweaks` branch. I will not be making any further changes.