### PR TITLE
Correct a Typo in the Event Record Runnable

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/runnables/PlayerTouchingPortalTask.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/runnables/PlayerTouchingPortalTask.java
@@ -25,7 +25,7 @@ public class PlayerTouchingPortalTask extends BukkitRunnable {
         PortalType type = null;
         Player p = Bukkit.getPlayer(this.uuid);
 
-        if (p != null && !p.isOnline()) {
+        if (p != null && p.isOnline()) {
             if (p.getLocation().getBlock().getType() == Material.END_PORTAL) {
                 type = PortalType.ENDER;
             } else if (p.getLocation().getBlock().getType() == Material.NETHER_PORTAL) {


### PR DESCRIPTION
This PR fixes a typo which causes all players in the event record to be removed from the event record when the runnable is first executed (10 seconds after they're added).