### PR TITLE
Better error checking for link and unlink commands.

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/MultiverseNetherPortals.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/MultiverseNetherPortals.java
@@ -262,21 +262,20 @@ public class MultiverseNetherPortals extends JavaPlugin implements MVPlugin {
         }
 
         this.MVNPConfiguration.set("worlds." + from + ".portalgoesto." + type, to);
-        this.saveMVNPConfig();
-        return true;
+        return this.saveMVNPConfig();
     }
 
-    public void removeWorldLink(String from, String to, PortalType type) {
+    public boolean removeWorldLink(String from, String to, PortalType type) {
         if (type == PortalType.NETHER) {
             this.linkMap.remove(from);
         } else if (type == PortalType.ENDER) {
             this.endLinkMap.remove(from);
         } else {
-            return;
+            return false;
         }
 
         this.MVNPConfiguration.set("worlds." + from + ".portalgoesto." + type, null);
-        this.saveMVNPConfig();
+        return this.saveMVNPConfig();
     }
 
     public boolean saveMVNPConfig() {

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/MultiverseNetherPortals.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/MultiverseNetherPortals.java
@@ -265,7 +265,7 @@ public class MultiverseNetherPortals extends JavaPlugin implements MVPlugin {
         return this.saveMVNPConfig();
     }
 
-    public boolean removeWorldLink(String from, String to, PortalType type) {
+    public boolean deleteWorldLink(String from, String to, PortalType type) {
         if (type == PortalType.NETHER) {
             this.linkMap.remove(from);
         } else if (type == PortalType.ENDER) {
@@ -276,6 +276,14 @@ public class MultiverseNetherPortals extends JavaPlugin implements MVPlugin {
 
         this.MVNPConfiguration.set("worlds." + from + ".portalgoesto." + type, null);
         return this.saveMVNPConfig();
+    }
+
+    /**
+     * @deprecated Use {@link MultiverseNetherPortals#deleteWorldLink(String, String, PortalType)} instead.
+     */
+    @Deprecated
+    public void removeWorldLink(String from, String to, PortalType type) {
+        deleteWorldLink(from, to, type);
     }
 
     public boolean saveMVNPConfig() {

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/commands/LinkCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/commands/LinkCommand.java
@@ -77,7 +77,11 @@ public class LinkCommand extends NetherPortalCommand {
             return;
         }
 
-        this.plugin.addWorldLink(fromWorld.getName(), toWorld.getName(), type);
+        if (!this.plugin.addWorldLink(fromWorld.getName(), toWorld.getName(), type)) {
+            sender.sendMessage(ChatColor.RED + "There was an error linking the portals! Please check console for errors.");
+            return;
+        }
+
         String coloredFrom = fromWorld.getColoredWorldString();
         String coloredTo = toWorld.getColoredWorldString();
         if (fromWorld.getName().equals(toWorld.getName())) {

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/commands/UnlinkCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/commands/UnlinkCommand.java
@@ -71,7 +71,7 @@ public class UnlinkCommand extends NetherPortalCommand {
             return;
         }
 
-        if (!this.plugin.removeWorldLink(fromWorldString, toWorldString, type)) {
+        if (!this.plugin.deleteWorldLink(fromWorldString, toWorldString, type)) {
             sender.sendMessage(ChatColor.RED + "There was an error unlinking the portals! Please check console for errors.");
             return;
         }

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/commands/UnlinkCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/commands/UnlinkCommand.java
@@ -63,22 +63,22 @@ public class UnlinkCommand extends NetherPortalCommand {
         }
 
         fromWorld = this.worldManager.getMVWorld(fromWorldString);
-        if (fromWorld == null) {
-            sender.sendMessage(ChatColor.RED + "Whoops!" + ChatColor.WHITE + " Doesn't look like Multiverse knows about '" + fromWorldString + "'");
-            return;
-        }
+        String coloredFrom = (fromWorld == null) ? fromWorldString : fromWorld.getColoredWorldString();
 
-        toWorldString = this.plugin.getWorldLink(fromWorld.getName(), type);
+        toWorldString = this.plugin.getWorldLink(fromWorldString, type);
         if (toWorldString == null) {
-            sender.sendMessage(ChatColor.RED + "Whoops!" + ChatColor.WHITE + " The world " + fromWorld.getColoredWorldString() + ChatColor.WHITE + " was never linked.");
+            sender.sendMessage(ChatColor.RED + "Whoops!" + ChatColor.WHITE + " The world " + coloredFrom + ChatColor.WHITE + " was never linked.");
             return;
         }
+
+        if (!this.plugin.removeWorldLink(fromWorldString, toWorldString, type)) {
+            sender.sendMessage(ChatColor.RED + "There was an error unlinking the portals! Please check console for errors.");
+            return;
+        }
+
         toWorld = this.worldManager.getMVWorld(toWorldString);
+        String coloredTo = (toWorld == null) ? toWorldString : toWorld.getColoredWorldString();
 
-        String coloredFrom = fromWorld.getColoredWorldString();
-        String coloredTo = toWorld.getColoredWorldString();
         sender.sendMessage("The " + type + " portals in " + coloredFrom + ChatColor.WHITE + " are now " + ChatColor.RED + "unlinked" + ChatColor.WHITE + " from " + coloredTo + ChatColor.WHITE + ".");
-        this.plugin.removeWorldLink(fromWorld.getName(), toWorld.getName(), type);
     }
-
 }


### PR DESCRIPTION
`saveMVNPConfig()` result should be used to ensure removing and adding of world link is saved to config properly.

Also, unlink command shouldn't need to check for MVWorld bcu users should be able to unlink world that they already have deleted/unloaded.

While doing this, also found a bug where it throws NPE (https://bytebin.lucko.me/1sI4jrxziC) if unlinking a toWorld that is not MVWorld which is fixed in this pr. 