### PR TITLE
Fix bug where config isnt updated on reload.

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPCoreListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPCoreListener.java
@@ -24,7 +24,7 @@ public class MVNPCoreListener implements Listener {
      */
     @EventHandler
     public void configReloadEvent(MVConfigReloadEvent event) {
-        this.plugin.reloadConfig();
+        this.plugin.loadConfig();
         event.addConfig("Multiverse-NetherPortals - config.yml");
     }
 


### PR DESCRIPTION
While testing #205, I found that `mv reload` doesn't update the config change. Looks like its due to calling the wrong load method, so just a simple fix for it.