### PR TITLE
Have common instance for MVLinkChecker and MVNameChecker.

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/MultiverseNetherPortals.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/MultiverseNetherPortals.java
@@ -20,6 +20,8 @@ import com.onarandombox.MultiverseNetherPortals.listeners.MVNPCoreListener;
 import com.onarandombox.MultiverseNetherPortals.listeners.MVNPEntityListener;
 import com.onarandombox.MultiverseNetherPortals.listeners.MVNPPlayerListener;
 import com.onarandombox.MultiverseNetherPortals.listeners.MVNPPluginListener;
+import com.onarandombox.MultiverseNetherPortals.utils.MVLinkChecker;
+import com.onarandombox.MultiverseNetherPortals.utils.MVNameChecker;
 import com.onarandombox.MultiversePortals.MultiversePortals;
 import com.onarandombox.commandhandler.CommandHandler;
 import org.bukkit.Location;
@@ -53,6 +55,8 @@ public class MultiverseNetherPortals extends JavaPlugin implements MVPlugin {
     protected CommandHandler commandHandler;
     private final static int requiresProtocol = 24;
     private MVNPEntityListener entityListener;
+    private MVLinkChecker linkChecker;
+    private MVNameChecker nameChecker;
 
     @Override
     public void onEnable() {
@@ -80,6 +84,9 @@ public class MultiverseNetherPortals extends JavaPlugin implements MVPlugin {
 
         this.core.incrementPluginCount();
         // As soon as we know MVCore was found, we can use the debug log!
+
+        this.linkChecker = new MVLinkChecker(this);
+        this.nameChecker = new MVNameChecker(this);
 
         this.pluginListener = new MVNPPluginListener(this);
         this.playerListener = new MVNPPlayerListener(this);
@@ -334,6 +341,14 @@ public class MultiverseNetherPortals extends JavaPlugin implements MVPlugin {
             }
         }
         return true;
+    }
+
+    public MVLinkChecker getLinkChecker() {
+        return linkChecker;
+    }
+
+    public MVNameChecker getNameChecker() {
+        return nameChecker;
     }
 
     public void setPortals(Plugin multiversePortals) {

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
@@ -52,8 +52,8 @@ public class MVNPEntityListener implements Listener {
 
     public MVNPEntityListener(MultiverseNetherPortals plugin) {
         this.plugin = plugin;
-        this.nameChecker = new MVNameChecker(this.plugin);
-        this.linkChecker = new MVLinkChecker(this.plugin);
+        this.nameChecker = this.plugin.getNameChecker();
+        this.linkChecker = this.plugin.getLinkChecker();
         this.worldManager = this.plugin.getCore().getMVWorldManager();
         this.pt = new PermissionTools(this.plugin.getCore());
         this.playerErrors = new HashMap<String, Date>();

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
@@ -31,10 +31,10 @@ public class MVNPPlayerListener implements Listener {
 
     public MVNPPlayerListener(MultiverseNetherPortals plugin) {
         this.plugin = plugin;
-        this.nameChecker = new MVNameChecker(plugin);
+        this.nameChecker = this.plugin.getNameChecker();
         this.worldManager = this.plugin.getCore().getMVWorldManager();
         this.pt = new PermissionTools(this.plugin.getCore());
-        this.linkChecker = new MVLinkChecker(this.plugin);
+        this.linkChecker = this.plugin.getLinkChecker();
     }
 
     @EventHandler


### PR DESCRIPTION
Probably won't have real-world improvements, but always best to not create objects when not needed.