### PR TITLE
Make entities appear at world spawn when they go trough exit end portal

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
@@ -5,6 +5,7 @@ import com.onarandombox.MultiverseCore.api.LocationManipulation;
 import com.onarandombox.MultiverseCore.api.MVWorldManager;
 import com.onarandombox.MultiverseCore.api.MultiverseMessaging;
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
+import com.onarandombox.MultiverseCore.api.SafeTTeleporter;
 import com.onarandombox.MultiverseCore.event.MVPlayerTouchedPortalEvent;
 import com.onarandombox.MultiverseCore.utils.PermissionTools;
 import com.onarandombox.MultiverseNetherPortals.MultiverseNetherPortals;
@@ -171,7 +172,9 @@ public class MVNPEntityListener implements Listener {
 
                 if (shouldAppearAtSpawn) {
                     MultiverseWorld tpTo = this.worldManager.getMVWorld(destinationWorld);
-                    newTo = this.linkChecker.findNewTeleportLocation(tpTo.getSpawnLocation(), destinationWorld, e);
+                    SafeTTeleporter teleporter = this.plugin.getCore().getSafeTTeleporter();
+                    Location safeSpawn = teleporter.getSafeLocation(tpTo.getSpawnLocation());
+                    newTo = this.linkChecker.findNewTeleportLocation(safeSpawn, destinationWorld, e);
                 } else {
                     newTo = this.linkChecker.findNewTeleportLocation(currentLocation, destinationWorld, e);
                 }

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
@@ -146,9 +146,12 @@ public class MVNPEntityListener implements Listener {
             } else {
                 String destinationWorld = "";
 
+                boolean shouldAppearAtSpawn = false;
+
                 if (this.nameChecker.isValidEndName(currentWorld)) {
                     if (type == PortalType.ENDER) {
                         destinationWorld = this.nameChecker.getNormalName(currentWorld, type);
+                        shouldAppearAtSpawn = true;
                     } else if (type == PortalType.NETHER) {
                         destinationWorld = this.nameChecker.getNetherName(this.nameChecker.getNormalName(currentWorld, type));
                     }
@@ -166,7 +169,12 @@ public class MVNPEntityListener implements Listener {
                     }
                 }
 
-                newTo = this.linkChecker.findNewTeleportLocation(currentLocation, destinationWorld, e);
+                if (shouldAppearAtSpawn) {
+                    MultiverseWorld tpTo = this.worldManager.getMVWorld(destinationWorld);
+                    newTo = this.linkChecker.findNewTeleportLocation(tpTo.getSpawnLocation(), destinationWorld, e);
+                } else {
+                    newTo = this.linkChecker.findNewTeleportLocation(currentLocation, destinationWorld, e);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/Multiverse/Multiverse-Core/issues/2707.
Currently the getLocation on the entity listener was sending the entities on the same location from which the entity crossed the portal from with taking the scaling into account, this is exactly the same behavior it is used for nether portals, however this is not the correct behavior when going from the end to the overworld, since the end portal is mostly always at 0,0 the items will always spawn close to 0,0 in the overworld.

The mean to fix this is by adding a special flag for when the portal is an end portal and the from world is the end, If this flag is true it will teleport specifically to the world's target spawn point