### PR TITLE
Fix wrong destination for entity portal teleport

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
@@ -331,10 +331,10 @@ public class MVNPEntityListener implements Listener {
         }
 
         PortalType type;
-        if (fromWorld.getEnvironment() == World.Environment.NETHER
+        if (originalToWorld.getEnvironment() == World.Environment.NETHER
                 || (fromWorld.getEnvironment() == World.Environment.NETHER && originalToWorld.getEnvironment() == World.Environment.NORMAL)) {
             type = PortalType.NETHER;
-        } else if (fromWorld.getEnvironment() == World.Environment.THE_END
+        } else if (originalToWorld.getEnvironment() == World.Environment.THE_END
                 || (fromWorld.getEnvironment() == World.Environment.THE_END && originalToWorld.getEnvironment() == World.Environment.NORMAL)) {
             type = PortalType.ENDER;
         } else {


### PR DESCRIPTION
Previously toLocation and toWorld is used to create the new destination portal which is wrong, as that is the original value by the event, and not the new location by the np-portal linking. Renamed the variables to clearly reflect if the variable is the original or new location.