### PR TITLE
Fix entity location when going through end portal

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
@@ -316,11 +316,10 @@ public class MVNPEntityListener implements Listener {
             return;
         }
 
-        // Some shortcuts for later
         Entity entity = event.getEntity();
 
-        Location fromLocation = this.locationManipulation.getBlockLocation(event.getFrom());
-        Location originalToLocation = this.locationManipulation.getBlockLocation(event.getTo());
+        Location fromLocation = event.getFrom();
+        Location originalToLocation = event.getTo();
 
         World fromWorld = fromLocation.getWorld();
         World originalToWorld = originalToLocation.getWorld();
@@ -388,7 +387,7 @@ public class MVNPEntityListener implements Listener {
         }
         // If we are going to the end from anywhere
         else if (newToWorld.getEnvironment() == World.Environment.THE_END && type == PortalType.ENDER) {
-            Location spawnLocation = EndPlatformCreator.getVanillaLocation(newToWorld);
+            Location spawnLocation = EndPlatformCreator.getVanillaLocation(entity, newToWorld);
             event.setTo(spawnLocation);
             EndPlatformCreator.createEndPlatform(spawnLocation, plugin.isEndPlatformDropBlocks());
         }

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
@@ -389,7 +389,7 @@ public class MVNPEntityListener implements Listener {
         else if (newToWorld.getEnvironment() == World.Environment.THE_END && type == PortalType.ENDER) {
             Location spawnLocation = EndPlatformCreator.getVanillaLocation(entity, newToWorld);
             event.setTo(spawnLocation);
-            EndPlatformCreator.createEndPlatform(spawnLocation, plugin.isEndPlatformDropBlocks());
+            EndPlatformCreator.createEndPlatform(spawnLocation.getWorld(), plugin.isEndPlatformDropBlocks());
         }
     }
 

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
@@ -64,12 +64,14 @@ public class MVNPPlayerListener implements Listener {
             return;
         }
 
+        Player player = event.getPlayer();
+
         if (type == PortalType.NETHER) {
             try {
                 Class.forName("org.bukkit.TravelAgent");
                 event.useTravelAgent(true);
             } catch (ClassNotFoundException ignore) {
-                Logging.fine("TravelAgent not available for PlayerPortalEvent for " + event.getPlayer().getName());
+                Logging.fine("TravelAgent not available for PlayerPortalEvent for " + player.getName());
             }
         }
 
@@ -79,24 +81,24 @@ public class MVNPPlayerListener implements Listener {
         if (currentWorld.equalsIgnoreCase(linkedWorld)) {
             newTo = null;
         } else if (linkedWorld != null) {
-            newTo = this.linkChecker.findNewTeleportLocation(currentLocation, linkedWorld, event.getPlayer());
+            newTo = this.linkChecker.findNewTeleportLocation(currentLocation, linkedWorld, player);
         } else if (this.nameChecker.isValidNetherName(currentWorld)) {
             if (type == PortalType.NETHER) {
-                newTo = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getNormalName(currentWorld, PortalType.NETHER), event.getPlayer());
+                newTo = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getNormalName(currentWorld, PortalType.NETHER), player);
             } else {
-                newTo = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getEndName(this.nameChecker.getNormalName(currentWorld, PortalType.NETHER)), event.getPlayer());
+                newTo = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getEndName(this.nameChecker.getNormalName(currentWorld, PortalType.NETHER)), player);
             }
         } else if (this.nameChecker.isValidEndName(currentWorld)) {
             if (type == PortalType.NETHER) {
-                newTo = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getNetherName(this.nameChecker.getNormalName(currentWorld, PortalType.ENDER)), event.getPlayer());
+                newTo = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getNetherName(this.nameChecker.getNormalName(currentWorld, PortalType.ENDER)), player);
             } else {
-                newTo = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getNormalName(currentWorld, PortalType.ENDER), event.getPlayer());
+                newTo = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getNormalName(currentWorld, PortalType.ENDER), player);
             }
         } else {
             if (type == PortalType.ENDER) {
-                newTo = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getEndName(currentWorld), event.getPlayer());
+                newTo = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getEndName(currentWorld), player);
             } else {
-                newTo = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getNetherName(currentWorld), event.getPlayer());
+                newTo = this.linkChecker.findNewTeleportLocation(currentLocation, this.nameChecker.getNetherName(currentWorld), player);
             }
         }
 
@@ -112,17 +114,17 @@ public class MVNPPlayerListener implements Listener {
 
         if (!event.isCancelled()) {
             if (fromWorld.getEnvironment() == World.Environment.THE_END && type == PortalType.ENDER) {
-                Logging.fine("Player '" + event.getPlayer().getName() + "' will be teleported to the spawn of '" + toWorld.getName() + "' since they used an end exit portal.");
+                Logging.fine("Player '" + player.getName() + "' will be teleported to the spawn of '" + toWorld.getName() + "' since they used an end exit portal.");
                 try {
                     Class.forName("org.bukkit.TravelAgent");
                     event.getPortalTravelAgent().setCanCreatePortal(false);
                 } catch (ClassNotFoundException ignore) {
-                    Logging.fine("TravelAgent not available for PlayerPortalEvent for " + event.getPlayer().getName() + ". There may be a portal created at spawn.");
+                    Logging.fine("TravelAgent not available for PlayerPortalEvent for " + player.getName() + ". There may be a portal created at spawn.");
                 }
                 if (toWorld.getBedRespawn()
-                        && event.getPlayer().getBedSpawnLocation() != null
-                        && event.getPlayer().getBedSpawnLocation().getWorld().getUID() == toWorld.getCBWorld().getUID()) {
-                    event.setTo(event.getPlayer().getBedSpawnLocation());
+                        && player.getBedSpawnLocation() != null
+                        && player.getBedSpawnLocation().getWorld().getUID() == toWorld.getCBWorld().getUID()) {
+                    event.setTo(player.getBedSpawnLocation());
                 } else {
                     event.setTo(toWorld.getSpawnLocation());
                 }
@@ -132,20 +134,20 @@ public class MVNPPlayerListener implements Listener {
                     event.getPortalTravelAgent().setCanCreatePortal(true);
                     event.setTo(event.getPortalTravelAgent().findOrCreate(event.getTo()));
                 } catch (ClassNotFoundException ignore) {
-                    Logging.fine("TravelAgent not available for PlayerPortalEvent for " + event.getPlayer().getName() + ". Their destination may not be correct.");
+                    Logging.fine("TravelAgent not available for PlayerPortalEvent for " + player.getName() + ". Their destination may not be correct.");
                     event.setTo(event.getTo());
                 }
             } else if (toWorld.getEnvironment() == World.Environment.THE_END && type == PortalType.ENDER) {
-                Location spawnLocation = EndPlatformCreator.getVanillaLocation(event.getTo().getWorld());
+                Location spawnLocation = EndPlatformCreator.getVanillaLocation(player, event.getTo().getWorld());
                 event.setTo(spawnLocation);
                 EndPlatformCreator.createEndPlatform(spawnLocation, plugin.isEndPlatformDropBlocks());
             }
 
             // Advancements need to be triggered manually
             if (type == PortalType.NETHER && event.getTo().getWorld().getEnvironment() == World.Environment.NETHER) {
-                awardAdvancement(event.getPlayer(), enterNetherAdvancement, ENTER_NETHER_CRITERIA);
+                awardAdvancement(player, enterNetherAdvancement, ENTER_NETHER_CRITERIA);
             } else if (type == PortalType.ENDER && event.getTo().getWorld().getEnvironment() == World.Environment.THE_END) {
-                awardAdvancement(event.getPlayer(), enterEndAdvancement, ENTER_END_CRITERIA);
+                awardAdvancement(player, enterEndAdvancement, ENTER_END_CRITERIA);
             }
         }
     }

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
@@ -140,7 +140,7 @@ public class MVNPPlayerListener implements Listener {
             } else if (toWorld.getEnvironment() == World.Environment.THE_END && type == PortalType.ENDER) {
                 Location spawnLocation = EndPlatformCreator.getVanillaLocation(player, event.getTo().getWorld());
                 event.setTo(spawnLocation);
-                EndPlatformCreator.createEndPlatform(spawnLocation, plugin.isEndPlatformDropBlocks());
+                EndPlatformCreator.createEndPlatform(spawnLocation.getWorld(), plugin.isEndPlatformDropBlocks());
             }
 
             // Advancements need to be triggered manually

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/utils/EndPlatformCreator.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/utils/EndPlatformCreator.java
@@ -15,11 +15,12 @@ public class EndPlatformCreator {
     /**
      * Creates an end platform at the specified {@code Block}
      *
-     * @param spawnLocation The {@code Block} that the player will spawn at.
+     * @param world The world to create the platform in
      * @param dropEndBlocks If the platform should drop the broken blocks or delete them
      */
-    public static void createEndPlatform(Block spawnLocation, boolean dropEndBlocks) {
-        Logging.fine("Creating an end platform at " + spawnLocation.toString());
+    public static void createEndPlatform(World world, boolean dropEndBlocks) {
+        Block spawnLocation = new Location(world, 100, 49, 0).getBlock();
+        Logging.fine("Creating an end platform at " + spawnLocation);
 
         for (int x = spawnLocation.getX() - 2; x <= spawnLocation.getX() + 2; x++) {
             for (int z = spawnLocation.getZ() - 2; z <= spawnLocation.getZ() + 2; z++) {
@@ -36,26 +37,14 @@ public class EndPlatformCreator {
                 for (int yMod = 1; yMod <= 3; yMod++) {
                     Block block = platformBlock.getRelative(BlockFace.UP, yMod);
                     if (block.getType() != Material.AIR) {
-                        if (dropEndBlocks) {
-                            block.breakNaturally();
-                        } else {
+                        if (!dropEndBlocks || !block.breakNaturally()) {
                             block.setType(Material.AIR);
                         }
-
-                        Logging.finest("Breaking block at " + platformBlock);
+                        Logging.finest("Breaking block at " + block);
                     }
                 }
             }
         }
-    }
-
-
-    /**
-     * Creates an end platform at the specified {@code Location}
-     * @param spawnLocation The {@code Location} that the player will spawn at.
-     */
-    public static void createEndPlatform(Location spawnLocation, boolean dropEndBlocks) {
-        createEndPlatform(spawnLocation.getBlock(), dropEndBlocks);
     }
 
     /**

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/utils/EndPlatformCreator.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/utils/EndPlatformCreator.java
@@ -2,12 +2,13 @@ package com.onarandombox.MultiverseNetherPortals.utils;
 
 import com.dumptruckman.minecraft.util.Logging;
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
-import com.onarandombox.MultiverseNetherPortals.MultiverseNetherPortals;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 
 public class EndPlatformCreator {
 
@@ -60,14 +61,16 @@ public class EndPlatformCreator {
     /**
      * The default vanilla location for the end platform
      */
-    public static Location getVanillaLocation(World world) {
-        return new Location(world, 100, 49, 0, 90, 0);
+    public static Location getVanillaLocation(Entity entity, World world) {
+        return entity instanceof Player
+                ? new Location(world, 100, 49, 0, 90, 0)
+                : new Location(world, 100.5, 50, 0.5, 90, 0);
     }
 
     /**
      * The default vanilla location for the end platform
      */
-    public static Location getVanillaLocation(MultiverseWorld world) {
-        return getVanillaLocation(world.getCBWorld());
+    public static Location getVanillaLocation(Entity entity, MultiverseWorld world) {
+        return getVanillaLocation(entity, world.getCBWorld());
     }
 }


### PR DESCRIPTION
According to a minecraft wiki and my testing: 
```
Players who enter the End spawn at coordinates (100, 49, 0), facing west toward the main island;
other entities that enter the End spawn at coordinates (100.5, 50, 0.5), in the middle of and 1 block higher than the platform.
```
[15:27:56 INFO]: [Multiverse-NetherPortals] Entity Jungle Planks is teleporting from Location{world=CraftWorld{name=world},x=-11.78125,y=70.6005859375,z=10.139892578125,pitch=0.0,yaw=95.308624} to Location{world=CraftWorld{name=world_the_end},x=100.5,y=50.0,z=0.5,pitch=0.0,yaw=90.0}
[15:28:43 INFO]: [Multiverse-NetherPortals] Entity Villager is teleporting from Location{world=CraftWorld{name=world},x=-11.5,y=70.0,z=10.5,pitch=0.0,yaw=165.47754} to Location{world=CraftWorld{name=world_the_end},x=100.5,y=50.0,z=0.5,pitch=0.0,yaw=90.0}
```