### PR TITLE
Cache TravelAgent check result

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPEntityListener.java
@@ -9,10 +9,7 @@ import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseCore.event.MVPlayerTouchedPortalEvent;
 import com.onarandombox.MultiverseCore.utils.PermissionTools;
 import com.onarandombox.MultiverseNetherPortals.MultiverseNetherPortals;
-import com.onarandombox.MultiverseNetherPortals.utils.EndPlatformCreator;
-import com.onarandombox.MultiverseNetherPortals.utils.MVEventRecord;
-import com.onarandombox.MultiverseNetherPortals.utils.MVLinkChecker;
-import com.onarandombox.MultiverseNetherPortals.utils.MVNameChecker;
+import com.onarandombox.MultiverseNetherPortals.utils.*;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.PortalType;
@@ -342,10 +339,9 @@ public class MVNPEntityListener implements Listener {
 
         // Are we allowed to use the nether portal travel agent?
         if (type == PortalType.NETHER) {
-            try {
-                Class.forName("org.bukkit.TravelAgent");
+            if (ClassChecker.isTravelAgentExists) {
                 event.useTravelAgent(true);
-            } catch (ClassNotFoundException ignore) {
+            } else {
                 Logging.fine("TravelAgent not available for EntityPortalEvent for " + entity.getName());
             }
         }
@@ -366,21 +362,19 @@ public class MVNPEntityListener implements Listener {
         // If we are going to the overworld from the end
         if (fromWorld.getEnvironment() == World.Environment.THE_END && type == PortalType.ENDER) {
             Logging.fine("Entity '" + entity.getName() + "' will be teleported to the spawn of '" + newToWorld.getName() + "' since they used an end exit portal.");
-            try {
-                Class.forName("org.bukkit.TravelAgent");
+            if (ClassChecker.isTravelAgentExists) {
                 event.getPortalTravelAgent().setCanCreatePortal(false);
-            } catch (ClassNotFoundException ignore) {
+            } else {
                 Logging.fine("TravelAgent not available for EntityPortalEvent for " + entity.getName() + ". There may be a portal created at spawn.");
             }
             event.setTo(newToWorld.getSpawnLocation());
         }
         // If we are going to the overworld from the nether
         else if (fromWorld.getEnvironment() == World.Environment.NETHER && type == PortalType.NETHER) {
-            try {
-                Class.forName("org.bukkit.TravelAgent");
+            if (ClassChecker.isTravelAgentExists) {
                 event.getPortalTravelAgent().setCanCreatePortal(true);
                 event.setTo(event.getPortalTravelAgent().findOrCreate(newToLocation));
-            } catch (ClassNotFoundException ignore) {
+            } else {
                 Logging.fine("TravelAgent not available for EntityPortalEvent for " + entity.getName() + ". Their destination may not be correct.");
                 event.setTo(newToLocation);
             }

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/listeners/MVNPPlayerListener.java
@@ -5,6 +5,7 @@ import com.onarandombox.MultiverseCore.api.MVWorldManager;
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseCore.utils.PermissionTools;
 import com.onarandombox.MultiverseNetherPortals.MultiverseNetherPortals;
+import com.onarandombox.MultiverseNetherPortals.utils.ClassChecker;
 import com.onarandombox.MultiverseNetherPortals.utils.EndPlatformCreator;
 import com.onarandombox.MultiverseNetherPortals.utils.MVLinkChecker;
 import com.onarandombox.MultiverseNetherPortals.utils.MVNameChecker;
@@ -67,10 +68,9 @@ public class MVNPPlayerListener implements Listener {
         Player player = event.getPlayer();
 
         if (type == PortalType.NETHER) {
-            try {
-                Class.forName("org.bukkit.TravelAgent");
+            if (ClassChecker.isTravelAgentExists) {
                 event.useTravelAgent(true);
-            } catch (ClassNotFoundException ignore) {
+            } else {
                 Logging.fine("TravelAgent not available for PlayerPortalEvent for " + player.getName());
             }
         }
@@ -115,10 +115,9 @@ public class MVNPPlayerListener implements Listener {
         if (!event.isCancelled()) {
             if (fromWorld.getEnvironment() == World.Environment.THE_END && type == PortalType.ENDER) {
                 Logging.fine("Player '" + player.getName() + "' will be teleported to the spawn of '" + toWorld.getName() + "' since they used an end exit portal.");
-                try {
-                    Class.forName("org.bukkit.TravelAgent");
+                if (ClassChecker.isTravelAgentExists) {
                     event.getPortalTravelAgent().setCanCreatePortal(false);
-                } catch (ClassNotFoundException ignore) {
+                } else {
                     Logging.fine("TravelAgent not available for PlayerPortalEvent for " + player.getName() + ". There may be a portal created at spawn.");
                 }
                 if (toWorld.getBedRespawn()
@@ -129,11 +128,10 @@ public class MVNPPlayerListener implements Listener {
                     event.setTo(toWorld.getSpawnLocation());
                 }
             } else if (fromWorld.getEnvironment() == World.Environment.NETHER && type == PortalType.NETHER) {
-                try {
-                    Class.forName("org.bukkit.TravelAgent");
+                if (ClassChecker.isTravelAgentExists) {
                     event.getPortalTravelAgent().setCanCreatePortal(true);
                     event.setTo(event.getPortalTravelAgent().findOrCreate(event.getTo()));
-                } catch (ClassNotFoundException ignore) {
+                } else {
                     Logging.fine("TravelAgent not available for PlayerPortalEvent for " + player.getName() + ". Their destination may not be correct.");
                     event.setTo(event.getTo());
                 }

--- a/src/main/java/com/onarandombox/MultiverseNetherPortals/utils/ClassChecker.java
+++ b/src/main/java/com/onarandombox/MultiverseNetherPortals/utils/ClassChecker.java
@@ -1,0 +1,19 @@
+package com.onarandombox.MultiverseNetherPortals.utils;
+
+public class ClassChecker {
+    public static final boolean isTravelAgentExists = isClassLoaded("org.bukkit.TravelAgent");
+
+    /**
+     * Checks if a class is loaded
+     * @param className The full-qualified name of the class
+     * @return true if the class is loaded, false otherwise
+     */
+    public static boolean isClassLoaded(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
This pull request caches Class.forName("org.bukkit.TravelAgent") check result as it's a bit expensive in some situations and no need to check for multiple times.

## Changes

- Added class ClassChecker to check and cache the TravelAgent existence result.

Spark profiler screenshot below shows this call is pretty expensive in servers.

![6C5420D78A345906E65FB6C53D162728](https://github.com/user-attachments/assets/fc0d8c40-cfc3-4bf1-800f-7b02b3b96fc2)
