### PR TITLE
Don't do entry check when getting portal destination, let mvcore handle it

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/netherportals/utils/MVLinkChecker.java
+++ b/src/main/java/org/mvplugins/multiverse/netherportals/utils/MVLinkChecker.java
@@ -27,8 +27,6 @@ public class MVLinkChecker {
 
         if (tpTo == null) {
             Logging.fine("Can't find world " + worldString);
-        } else if (e instanceof Player && !this.entryCheckerProvider.forSender(e).canEnterWorld(tpFrom, tpTo).isSuccess()) {
-            Logging.warning("Player " + e.getName() + " can't enter world " + worldString);
         } else if (!this.worldManager.isLoadedWorld(fromLocation.getWorld())) {
             Logging.warning("World " + fromLocation.getWorld().getName() + " is not a Multiverse world");
         } else {


### PR DESCRIPTION


<!-- artifact-comment-section 288 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-netherportals-pr288](https://nightly.link/Multiverse/Multiverse-NetherPortals/actions/runs/15374796867/multiverse-netherportals-pr288.zip)

<!-- artifact-comment-section 288 end (DO NOT EDIT ABOVE) -->