### PR TITLE
Fix link message only shows if world has an alias name

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/netherportals/commands/LinkCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/netherportals/commands/LinkCommand.java
@@ -59,8 +59,8 @@ class LinkCommand extends NetherPortalsCommand {
             throw new InvalidCommandArgument("There was an error creating the link! See console for more details.");
         }
 
-        String coloredFrom = fromWorld.getAlias();
-        String coloredTo = toWorld.getAlias();
+        String coloredFrom = fromWorld.getAliasOrName();
+        String coloredTo = toWorld.getAliasOrName();
 
         issuer.sendMessage((fromWorld.getName().equals(toWorld.getName()))
                 ? String.format("%sNOTE: %sYou have %ssuccessfully disabled %s%s Portals in %s.",


### PR DESCRIPTION


<!-- artifact-comment-section 290 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-netherportals-pr290](https://nightly.link/Multiverse/Multiverse-NetherPortals/actions/runs/15776437448/multiverse-netherportals-pr290.zip)

<!-- artifact-comment-section 290 end (DO NOT EDIT ABOVE) -->